### PR TITLE
feat: add session management endpoints for checking active sessions and closing other sessions

### DIFF
--- a/src/controllers/login.controller.ts
+++ b/src/controllers/login.controller.ts
@@ -30,6 +30,9 @@ import UserSession from "../models/userSession.model";
 import {
   createUserSession,
   getActiveSessionsWithUserInfo,
+  getLocationFromIP,
+  getActiveSessionsByEntity,
+  invalidateAllUserSessions,
 } from "../helpers/session.service";
 import { v4 as uuidv4 } from "uuid";
 
@@ -88,14 +91,23 @@ export const login = async (req: Request, res: Response) => {
     const expiresAt = new Date();
     expiresAt.setHours(expiresAt.getHours() + expirationHours);
 
-    // 2. Crear sesión (esto invalida automáticamente sesiones anteriores del usuario)
-    const { sessionId, session } = await createUserSession({
-      idUsuario: idEntidad,
+    // 2. Crear sesión (esto invalida automáticamente sesiones anteriores de la entidad)
+    const sessionParams: any = {
+      tipoEntidad: entidadTipo,
       ip: ipAddress,
       userAgent: userAgent,
       expiresAt: expiresAt,
       // refreshToken: null, // Para futuras implementaciones
-    });
+    };
+
+    // Asignar el ID correcto según el tipo de entidad
+    if (entidadTipo === "usuario") {
+      sessionParams.idUsuario = idEntidad;
+    } else {
+      sessionParams.idCongregacion = idEntidad;
+    }
+
+    const { sessionId, session } = await createUserSession(sessionParams);
 
     // 3. Generar JWT con sessionId incluido en el payload
     token = await generarJWT(
@@ -1254,6 +1266,205 @@ export const getActiveSessions = async (req: Request, res: Response) => {
     return res.status(500).json({
       ok: false,
       message: "Error al obtener sesiones activas",
+    });
+  }
+};
+
+/**
+ * Verifica si hay sesiones activas antes de hacer login
+ *
+ * Este endpoint valida las credenciales del usuario/congregación
+ * y retorna información sobre sesiones activas existentes sin cerrarlas.
+ * Permite al frontend mostrar una modal de confirmación.
+ *
+ * POST /api/login/check-sessions-before-login
+ *
+ * Body:
+ * {
+ *   login: string,
+ *   password: string
+ * }
+ *
+ * Response con sesiones activas:
+ * {
+ *   ok: true,
+ *   hasActiveSessions: true,
+ *   activeSessions: [
+ *     {
+ *       sessionId: "uuid",
+ *       device: { tipoDispositivo, navegador, so },
+ *       sessionLocation: { ciudad, pais, region }
+ *     }
+ *   ],
+ *   newLocation: { ciudad, pais }
+ * }
+ *
+ * Response sin sesiones activas:
+ * {
+ *   ok: true,
+ *   hasActiveSessions: false
+ * }
+ */
+export const checkSessionsBeforeLogin = async (req: Request, res: Response) => {
+  const { login, password } = req.body;
+  const ipAddress = ip || req.ip;
+
+  try {
+    let entidad;
+    let entidadTipo = "usuario";
+
+    // Verificar usuario
+    entidad = await verificarUsuario(login);
+
+    // Si no es un usuario, verificar si es una congregación
+    if (!entidad) {
+      entidad = await verificarCongregacion(login);
+      entidadTipo = "congregacion";
+    }
+
+    // Si no se encontró ni usuario ni congregación
+    if (!entidad) {
+      return res.status(404).json({
+        ok: false,
+        msg: "Usuario no válido",
+      });
+    }
+
+    // Verificar la contraseña
+    const isValidPassword = await verificarPassword(
+      password,
+      entidad.getDataValue("password"),
+    );
+
+    if (!isValidPassword) {
+      return res.status(404).json({
+        ok: false,
+        msg: "Contraseña no válida",
+      });
+    }
+
+    const idEntidad = entidad.getDataValue("id");
+
+    // Obtener sesiones activas de la entidad
+    const activeSessions = await getActiveSessionsByEntity(
+      entidadTipo === "usuario" ? idEntidad : undefined,
+      entidadTipo === "congregacion" ? idEntidad : undefined,
+    );
+
+    // Obtener ubicación del nuevo login
+    const newLocation = await getLocationFromIP(ipAddress);
+
+    if (activeSessions.length > 0) {
+      return res.json({
+        ok: true,
+        hasActiveSessions: true,
+        activeSessions: activeSessions.map((session) => ({
+          sessionId: session.sessionId,
+          device: session.device,
+          sessionLocation: session.sessionLocation,
+          timestamps: session.timestamps,
+        })),
+        newLocation: {
+          ciudad: newLocation.ciudad || "Desconocida",
+          pais: newLocation.pais || "Desconocido",
+          region: newLocation.region,
+        },
+      });
+    } else {
+      return res.json({
+        ok: true,
+        hasActiveSessions: false,
+        newLocation: {
+          ciudad: newLocation.ciudad || "Desconocida",
+          pais: newLocation.pais || "Desconocido",
+          region: newLocation.region,
+        },
+      });
+    }
+  } catch (error) {
+    console.error("Error al verificar sesiones antes del login:", error);
+    return res.status(500).json({
+      ok: false,
+      msg: "Error al verificar sesiones",
+    });
+  }
+};
+
+/**
+ * Cierra todas las sesiones activas del usuario actual excepto la sesión actual
+ *
+ * Este endpoint permite al usuario cerrar todas sus otras sesiones activas,
+ * útil cuando se detecta que hay sesiones no reconocidas.
+ *
+ * POST /api/login/close-other-sessions
+ *
+ * Headers:
+ * x-token: JWT token
+ *
+ * Response:
+ * {
+ *   ok: true,
+ *   closedSessions: 2,
+ *   message: "Sesiones cerradas exitosamente"
+ * }
+ */
+export const closeOtherSessions = async (req: CustomRequest, res: Response) => {
+  try {
+    const sessionId = req.sessionId;
+    const idUsuario = req.id;
+
+    if (!sessionId || !idUsuario) {
+      return res.status(400).json({
+        ok: false,
+        message: "Sesión no válida",
+      });
+    }
+
+    // Contar sesiones activas antes de cerrar
+    const sessionsBeforeClose = await UserSession.count({
+      where: {
+        idUsuario,
+        isActive: true,
+      },
+    });
+
+    // Cerrar todas las sesiones excepto la actual
+    const result = await UserSession.update(
+      {
+        isActive: false,
+        invalidationReason: "CLOSED_BY_USER",
+        invalidatedAt: new Date(),
+      },
+      {
+        where: {
+          idUsuario,
+          isActive: true,
+          sessionId: {
+            [Op.ne]: sessionId, // No cerrar la sesión actual
+          },
+        },
+      },
+    );
+
+    const closedSessions = result[0];
+
+    console.info(
+      `Usuario ${idUsuario} cerró ${closedSessions} sesiones remotas. Sesión actual: ${sessionId}`,
+    );
+
+    return res.json({
+      ok: true,
+      closedSessions,
+      message:
+        closedSessions > 0
+          ? `${closedSessions} sesión(es) cerrada(s) exitosamente`
+          : "No había otras sesiones activas",
+    });
+  } catch (error) {
+    console.error("Error al cerrar otras sesiones:", error);
+    return res.status(500).json({
+      ok: false,
+      message: "Error al cerrar sesiones",
     });
   }
 };

--- a/src/database/associations.ts
+++ b/src/database/associations.ts
@@ -262,6 +262,12 @@ Congregacion.belongsTo(Usuario, {
   as: "obreroEncargadoDos",
 });
 
+// Asociación de Congregación con País
+Congregacion.belongsTo(Pais, {
+  foreignKey: "pais_id",
+  as: "pais",
+});
+
 Campo.belongsTo(Usuario, {
   foreignKey: "idObreroEncargado",
   as: "obreroEncargado",

--- a/src/helpers/session.service.ts
+++ b/src/helpers/session.service.ts
@@ -36,7 +36,9 @@ interface LocationInfo {
 }
 
 interface CreateSessionParams {
-  idUsuario: number;
+  idUsuario?: number;
+  idCongregacion?: number;
+  tipoEntidad: "usuario" | "congregacion";
   ip: string;
   userAgent: string;
   expiresAt: Date;
@@ -154,18 +156,32 @@ export const getLocationFromIP = async (ip: string): Promise<LocationInfo> => {
 };
 
 /**
- * Invalida todas las sesiones activas de un usuario
+ * Invalida todas las sesiones activas de un usuario o congregación
  *
  * @param idUsuario - ID del usuario cuyas sesiones se invalidarán
+ * @param idCongregacion - ID de la congregación cuyas sesiones se invalidarán
  * @param reason - Razón de invalidación (opcional)
  * @param transaction - Transacción de Sequelize para atomicidad
  */
 export const invalidateAllUserSessions = async (
-  idUsuario: number,
+  idUsuario?: number,
+  idCongregacion?: number,
   reason: string = "NEW_LOGIN",
   transaction?: any,
 ): Promise<void> => {
   try {
+    const whereClause: any = {
+      isActive: true,
+    };
+
+    if (idUsuario) {
+      whereClause.idUsuario = idUsuario;
+    } else if (idCongregacion) {
+      whereClause.idCongregacion = idCongregacion;
+    } else {
+      throw new Error("Se debe proporcionar idUsuario o idCongregacion");
+    }
+
     await UserSession.update(
       {
         isActive: false,
@@ -173,16 +189,13 @@ export const invalidateAllUserSessions = async (
         invalidatedAt: new Date(),
       },
       {
-        where: {
-          idUsuario,
-          isActive: true,
-        },
+        where: whereClause,
         transaction,
       },
     );
   } catch (error) {
     console.error(
-      `Error al invalidar sesiones del usuario ${idUsuario}:`,
+      `Error al invalidar sesiones ${idUsuario ? `del usuario ${idUsuario}` : `de la congregación ${idCongregacion}`}:`,
       error,
     );
     throw new Error("Error al invalidar sesiones anteriores");
@@ -190,10 +203,10 @@ export const invalidateAllUserSessions = async (
 };
 
 /**
- * Crea una nueva sesión para un usuario
+ * Crea una nueva sesión para un usuario o congregación
  *
  * IMPORTANTE: Esta función invalida automáticamente todas las sesiones
- * activas anteriores del usuario antes de crear la nueva sesión.
+ * activas anteriores de la entidad antes de crear la nueva sesión.
  *
  * @param params - Parámetros para crear la sesión
  * @returns Objeto con sessionId generado y datos de la sesión
@@ -201,14 +214,37 @@ export const invalidateAllUserSessions = async (
 export const createUserSession = async (
   params: CreateSessionParams,
 ): Promise<{ sessionId: string; session: any }> => {
-  const { idUsuario, ip, userAgent, expiresAt, refreshToken } = params;
+  const {
+    idUsuario,
+    idCongregacion,
+    tipoEntidad,
+    ip,
+    userAgent,
+    expiresAt,
+    refreshToken,
+  } = params;
+
+  // Validar que se proporcione el ID correcto según el tipo de entidad
+  if (tipoEntidad === "usuario" && !idUsuario) {
+    throw new Error("Se debe proporcionar idUsuario para sesiones de usuario");
+  }
+  if (tipoEntidad === "congregacion" && !idCongregacion) {
+    throw new Error(
+      "Se debe proporcionar idCongregacion para sesiones de congregación",
+    );
+  }
 
   // Usar transacción para garantizar atomicidad
   const transaction = await db.transaction();
 
   try {
-    // 1. Invalidar todas las sesiones activas anteriores del usuario
-    await invalidateAllUserSessions(idUsuario, "NEW_LOGIN", transaction);
+    // 1. Invalidar todas las sesiones activas anteriores de la entidad
+    await invalidateAllUserSessions(
+      idUsuario,
+      idCongregacion,
+      "NEW_LOGIN",
+      transaction,
+    );
 
     // 2. Generar nuevo sessionId único
     const sessionId = uuidv4();
@@ -227,7 +263,9 @@ export const createUserSession = async (
     // 5. Crear nueva sesión activa
     const newSession = await UserSession.create(
       {
-        idUsuario,
+        tipoEntidad,
+        idUsuario: tipoEntidad === "usuario" ? idUsuario : null,
+        idCongregacion: tipoEntidad === "congregacion" ? idCongregacion : null,
         sessionId,
         refreshToken,
         ip,
@@ -253,8 +291,9 @@ export const createUserSession = async (
     // 6. Commit de la transacción
     await transaction.commit();
 
+    const entidadId = idUsuario || idCongregacion;
     console.info(
-      `Nueva sesión creada para usuario ${idUsuario}. SessionId: ${sessionId}, Ubicación: ${locationInfo.ciudad}, ${locationInfo.pais}`,
+      `Nueva sesión creada para ${tipoEntidad} ${entidadId}. SessionId: ${sessionId}, Ubicación: ${locationInfo.ciudad}, ${locationInfo.pais}`,
     );
 
     return {
@@ -533,7 +572,7 @@ export const cleanExpiredSessions = async (
  * Obtiene todas las sesiones activas con información del usuario y congregación
  *
  * Retorna:
- * - Total de sesiones activas
+ * - Total de sesiones activas de las últimas 48 horas
  * - Lista de sesiones con datos del usuario (nombre, apellidos)
  * - Información de congregación (país, ciudad, campo)
  * - Detalles de sesión (ubicación del login, dispositivo, IP)
@@ -542,14 +581,23 @@ export const cleanExpiredSessions = async (
  */
 export const getActiveSessionsWithUserInfo = async (): Promise<any> => {
   try {
+    // Calcular fecha límite: hace 48 horas
+    const fortyEightHoursAgo = new Date();
+    fortyEightHoursAgo.setHours(fortyEightHoursAgo.getHours() - 48);
+
     const activeSessions = await UserSession.findAll({
       where: {
         isActive: true,
+        createdAt: {
+          [Op.gte]: fortyEightHoursAgo, // Solo sesiones de las últimas 48 horas
+        },
       },
       attributes: [
         "id",
         "sessionId",
+        "tipoEntidad",
         "idUsuario",
+        "idCongregacion",
         "navegador",
         "so",
         "dispositivo",
@@ -611,6 +659,20 @@ export const getActiveSessionsWithUserInfo = async (): Promise<any> => {
             },
           ],
         },
+        {
+          model: Congregacion,
+          as: "congregacion",
+          attributes: ["id", "congregacion", "email", "pais_id"],
+          required: false,
+          include: [
+            {
+              model: Pais,
+              as: "pais",
+              attributes: ["id", "pais"],
+              required: false,
+            },
+          ],
+        },
       ],
       order: [["createdAt", "DESC"]],
     });
@@ -619,43 +681,74 @@ export const getActiveSessionsWithUserInfo = async (): Promise<any> => {
 
     const sessionsWithUserInfo = activeSessions.map((session) => {
       const sessionData = session.toJSON();
+      const tipoEntidad = sessionData.tipoEntidad;
       const usuario = sessionData.usuario;
+      const congregacion = sessionData.congregacion;
 
-      // Construir nombre completo desde los campos correctos
-      const primerNombre = usuario?.primerNombre || "";
-      const segundoNombre = usuario?.segundoNombre || "";
-      const primerApellido = usuario?.primerApellido || "";
-      const segundoApellido = usuario?.segundoApellido || "";
+      // Información base de la entidad
+      let entidadInfo: any = {};
 
-      const nombreCompleto = usuario
-        ? `${primerNombre} ${segundoNombre} ${primerApellido} ${segundoApellido}`
+      if (tipoEntidad === "usuario" && usuario) {
+        // Construir nombre completo desde los campos correctos
+        const primerNombre = usuario.primerNombre || "";
+        const segundoNombre = usuario.segundoNombre || "";
+        const primerApellido = usuario.primerApellido || "";
+        const segundoApellido = usuario.segundoApellido || "";
+
+        const nombreCompleto =
+          `${primerNombre} ${segundoNombre} ${primerApellido} ${segundoApellido}`
             .replace(/\s+/g, " ")
-            .trim()
-        : "N/A";
+            .trim();
 
-      // Obtener información de congregación desde usuarioCongregacion
-      const usuarioCongregacion = usuario?.usuarioCongregacion;
-      const paisObj = usuarioCongregacion?.pais;
-      const congregacionObj = usuarioCongregacion?.congregacion;
-      const campoObj = usuarioCongregacion?.campo;
+        // Obtener información de congregación del usuario
+        const usuarioCongregacion = usuario.usuarioCongregacion;
+        const paisObj = usuarioCongregacion?.pais;
+        const congregacionObj = usuarioCongregacion?.congregacion;
+        const campoObj = usuarioCongregacion?.campo;
 
-      return {
-        sessionId: sessionData.sessionId,
-        user: {
-          id: usuario?.id || null,
+        entidadInfo = {
+          tipo: "usuario",
+          id: usuario.id,
           primerNombre: primerNombre || "N/A",
           segundoNombre: segundoNombre || "N/A",
           primerApellido: primerApellido || "N/A",
           segundoApellido: segundoApellido || "N/A",
-          nombreCompleto: nombreCompleto,
-          login: usuario?.login || "N/A",
-          email: usuario?.email || "N/A",
-        },
-        congregacion: {
+          nombreCompleto: nombreCompleto || "N/A",
+          login: usuario.login || "N/A",
+          email: usuario.email || "N/A",
+          congregacion: {
+            pais: paisObj?.pais || "N/A",
+            nombre: congregacionObj?.congregacion || "N/A",
+            campo: campoObj?.campo || "N/A",
+          },
+        };
+      } else if (tipoEntidad === "congregacion" && congregacion) {
+        // Información de la congregación
+        // En congregaciones, el email funciona como login
+        const paisObj = congregacion.pais;
+
+        entidadInfo = {
+          tipo: "congregacion",
+          id: congregacion.id,
+          nombre: congregacion.congregacion || "N/A",
+          login: congregacion.email || "N/A", // El email es el login
+          email: congregacion.email || "N/A",
           pais: paisObj?.pais || "N/A",
-          ciudad: congregacionObj?.congregacion || "N/A",
-          campo: campoObj?.campo || "N/A",
-        },
+        };
+      } else {
+        // Entidad no encontrada o tipo desconocido
+        entidadInfo = {
+          tipo: tipoEntidad || "desconocido",
+          id: null,
+          nombre: "N/A",
+          login: "N/A",
+          email: "N/A",
+        };
+      }
+
+      return {
+        sessionId: sessionData.sessionId,
+        entidad: entidadInfo,
         sessionLocation: {
           pais: sessionData.pais || "N/A",
           ciudad: sessionData.ciudad || "N/A",
@@ -692,6 +785,82 @@ export const getActiveSessionsWithUserInfo = async (): Promise<any> => {
   }
 };
 
+/**
+ * Obtiene las sesiones activas de una entidad específica (usuario o congregación)
+ *
+ * @param idUsuario - ID del usuario (opcional)
+ * @param idCongregacion - ID de la congregación (opcional)
+ * @returns Array de sesiones activas con información detallada
+ */
+export const getActiveSessionsByEntity = async (
+  idUsuario?: number,
+  idCongregacion?: number,
+): Promise<any[]> => {
+  try {
+    const whereClause: any = {
+      isActive: true,
+    };
+
+    if (idUsuario) {
+      whereClause.idUsuario = idUsuario;
+    } else if (idCongregacion) {
+      whereClause.idCongregacion = idCongregacion;
+    } else {
+      throw new Error("Se debe proporcionar idUsuario o idCongregacion");
+    }
+
+    const sessions = await UserSession.findAll({
+      where: whereClause,
+      attributes: [
+        "sessionId",
+        "navegador",
+        "so",
+        "dispositivo",
+        "tipoDispositivo",
+        "pais",
+        "ciudad",
+        "region",
+        "ip",
+        "isp",
+        "createdAt",
+        "lastActivityAt",
+        "expiresAt",
+      ],
+      order: [["createdAt", "DESC"]],
+    });
+
+    return sessions.map((session) => {
+      const data = session.toJSON();
+      return {
+        sessionId: data.sessionId,
+        device: {
+          tipoDispositivo: data.tipoDispositivo || "desktop",
+          navegador: data.navegador || "Desconocido",
+          so: data.so || "Desconocido",
+          dispositivo: data.dispositivo || "Desconocido",
+        },
+        sessionLocation: {
+          ciudad: data.ciudad || "Desconocida",
+          pais: data.pais || "Desconocido",
+          region: data.region,
+        },
+        network: {
+          ip: data.ip,
+          isp: data.isp,
+        },
+        timestamps: {
+          createdAt: data.createdAt,
+          lastActivityAt: data.lastActivityAt,
+          expiresAt: data.expiresAt,
+        },
+      };
+    });
+  } catch (error) {
+    console.error("Error al obtener sesiones activas de la entidad:", error);
+    throw new Error("Error al obtener sesiones activas");
+  }
+};
+
 export default {
   createUserSession,
   validateUserSession,
@@ -701,4 +870,6 @@ export default {
   parseDeviceInfo,
   cleanExpiredSessions,
   getActiveSessionsWithUserInfo,
+  getLocationFromIP,
+  getActiveSessionsByEntity,
 };

--- a/src/models/userSession.model.ts
+++ b/src/models/userSession.model.ts
@@ -1,15 +1,16 @@
 import { DataTypes } from "sequelize";
 import db from "../database/connection";
 import Usuario from "./usuario.model";
+import Congregacion from "./congregacion.model";
 
 /**
  * Modelo UserSession
  *
- * Gestiona las sesiones activas de usuarios para implementar
- * una política de sesión única por usuario.
+ * Gestiona las sesiones activas de usuarios y congregaciones para implementar
+ * una política de sesión única por entidad.
  *
- * Solo puede haber una sesión activa por usuario a la vez.
- * Cuando un usuario inicia sesión desde un nuevo dispositivo,
+ * Solo puede haber una sesión activa por usuario/congregación a la vez.
+ * Cuando una entidad inicia sesión desde un nuevo dispositivo,
  * todas las sesiones anteriores son invalidadas automáticamente.
  */
 const UserSession = db.define(
@@ -20,15 +21,32 @@ const UserSession = db.define(
       primaryKey: true,
       autoIncrement: true,
     },
-    // ID del usuario al que pertenece la sesión
+    // Tipo de entidad: 'usuario' o 'congregacion'
+    tipoEntidad: {
+      type: DataTypes.ENUM("usuario", "congregacion"),
+      allowNull: false,
+      defaultValue: "usuario",
+      field: "tipoEntidad",
+    },
+    // ID del usuario al que pertenece la sesión (nullable para congregaciones)
     idUsuario: {
       type: DataTypes.INTEGER,
-      allowNull: false,
+      allowNull: true,
       references: {
         model: "usuario",
         key: "id",
       },
       field: "idUsuario",
+    },
+    // ID de la congregación al que pertenece la sesión (nullable para usuarios)
+    idCongregacion: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+      references: {
+        model: "congregacion",
+        key: "id",
+      },
+      field: "idCongregacion",
     },
     // Identificador único de la sesión (JWT ID - jti claim)
     // Se incluye en el payload del JWT para validación
@@ -150,13 +168,25 @@ const UserSession = db.define(
         fields: ["idUsuario"],
       },
       {
+        name: "idx_user_session_congregacionId",
+        fields: ["idCongregacion"],
+      },
+      {
         name: "idx_user_session_sessionId",
         unique: true,
         fields: ["sessionId"],
       },
       {
-        name: "idx_user_session_active",
+        name: "idx_user_session_active_usuario",
         fields: ["idUsuario", "isActive"],
+      },
+      {
+        name: "idx_user_session_active_congregacion",
+        fields: ["idCongregacion", "isActive"],
+      },
+      {
+        name: "idx_user_session_tipo_entidad",
+        fields: ["tipoEntidad", "isActive"],
       },
     ],
   },
@@ -166,6 +196,12 @@ const UserSession = db.define(
 UserSession.belongsTo(Usuario, {
   foreignKey: "idUsuario",
   as: "usuario",
+});
+
+// Asociación con Congregación
+UserSession.belongsTo(Congregacion, {
+  foreignKey: "idCongregacion",
+  as: "congregacion",
 });
 
 export default UserSession;

--- a/src/routes/login.routes.ts
+++ b/src/routes/login.routes.ts
@@ -16,6 +16,8 @@ import {
   resetPassword,
   checkSession,
   getActiveSessions,
+  checkSessionsBeforeLogin,
+  closeOtherSessions,
 } from "../controllers/login.controller";
 
 import validarCampos from "../middlewares/validar-campos";
@@ -31,6 +33,20 @@ router.get("/check-session", validarJWT, checkSession);
 
 // Get Active Sessions - Obtener todas las sesiones activas
 router.get("/active-sessions", getActiveSessions);
+
+// Check Sessions Before Login - Verificar sesiones antes de hacer login
+router.post(
+  "/check-sessions-before-login",
+  [
+    check("login", "El nombre de usuario es obligatorio").not().isEmpty(),
+    check("password", "El password es obligatorio").not().isEmpty(),
+    validarCampos,
+  ],
+  checkSessionsBeforeLogin,
+);
+
+// Close Other Sessions - Cerrar otras sesiones del usuario actual
+router.post("/close-other-sessions", validarJWT, closeOtherSessions);
 
 // Logout - Cerrar sesión
 router.post("/logout", validarJWT, logout);


### PR DESCRIPTION
This pull request introduces comprehensive support for session management for both users and congregations, replacing the previous user-only session logic with a unified "entity" model. It refactors session creation, invalidation, and querying to handle both entity types, and adds new endpoints for advanced session control and visibility. Additionally, it extends the data model and associations to support these changes.

**Session Management Enhancements**

* Refactored session creation, invalidation, and querying logic in `session.service.ts` and `userSession.model.ts` to support both users and congregations as session "entities". The session model now includes `tipoEntidad`, `idUsuario`, and `idCongregacion` fields, and all session operations are entity-aware. [[1]](diffhunk://#diff-90cd3e98cb13be87dd166acbfce953e559785d45bc9d1025d94330b8576f1b3bL23-R50) [[2]](diffhunk://#diff-424b57d95b20e726b0ee922b52c10b95bea2b61caf11a80ec361778daa12a639L39-R41) [[3]](diffhunk://#diff-424b57d95b20e726b0ee922b52c10b95bea2b61caf11a80ec361778daa12a639L157-R247) [[4]](diffhunk://#diff-424b57d95b20e726b0ee922b52c10b95bea2b61caf11a80ec361778daa12a639L230-R268) [[5]](diffhunk://#diff-424b57d95b20e726b0ee922b52c10b95bea2b61caf11a80ec361778daa12a639R294-R296)

* Added the `getActiveSessionsByEntity` function to retrieve all active sessions for a specific user or congregation, and refactored `invalidateAllUserSessions` and `createUserSession` to work for both entity types. [[1]](diffhunk://#diff-424b57d95b20e726b0ee922b52c10b95bea2b61caf11a80ec361778daa12a639R788-R863) [[2]](diffhunk://#diff-424b57d95b20e726b0ee922b52c10b95bea2b61caf11a80ec361778daa12a639R873-R874) [[3]](diffhunk://#diff-48a2ada10f70045fd749932b9de52b2bffa71c455bb3f637c658240d66f8cf11R33-R35)

**API and Controller Additions**

* Added new endpoints in `login.controller.ts`:
  - `checkSessionsBeforeLogin`: Allows the frontend to check for active sessions before login and display a confirmation modal if needed.
  - [`closeOtherSessions`](diffhunk://#diff-48a2ada10f70045fd749932b9de52b2bffa71c455bb3f637c658240d66f8cf11R1273-R1471): Enables a user to close all other sessions except the current one, for improved security.

* Updated the login flow to assign the correct entity ID and type when creating sessions, ensuring that both users and congregations are handled properly.

**Data Model and Associations**

* Updated the `UserSession` Sequelize model to support both users and congregations, and extended associations to include congregation-country relationships. [[1]](diffhunk://#diff-90cd3e98cb13be87dd166acbfce953e559785d45bc9d1025d94330b8576f1b3bL23-R50) [[2]](diffhunk://#diff-504d474a87c7bac4204a5b8259e0f7bf2b5fe4c7a6fff10ff783f9b4fe1b303eR265-R270)

**Session Reporting Improvements**

* Enhanced `getActiveSessionsWithUserInfo` to:
  - Include both user and congregation sessions in the results.
  - Limit results to sessions from the last 48 hours.
  - Provide unified entity info in the response, including country and congregation details. [[1]](diffhunk://#diff-424b57d95b20e726b0ee922b52c10b95bea2b61caf11a80ec361778daa12a639L536-R575) [[2]](diffhunk://#diff-424b57d95b20e726b0ee922b52c10b95bea2b61caf11a80ec361778daa12a639R584-R600) [[3]](diffhunk://#diff-424b57d95b20e726b0ee922b52c10b95bea2b61caf11a80ec361778daa12a639R662-R675) [[4]](diffhunk://#diff-424b57d95b20e726b0ee922b52c10b95bea2b61caf11a80ec361778daa12a639R684-R751)

These changes provide a robust foundation for managing sessions across both users and congregations, improving security and visibility for administrators and end-users.