### PR TITLE
fix: correct punctuation in environment configuration comment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@
 # CONFIGURACIÓN DE ENTORNO
 # ============================================
 
-# Entorno de ejecución (development, production, test)
+# Entorno de ejecución (development, production, test).
 NODE_ENV=development
 
 # Puerto del servidor


### PR DESCRIPTION
This pull request makes a minor update to the `.env.example` file, adjusting the comment for the `NODE_ENV` variable for clarity. No functional code changes are included.